### PR TITLE
fix crash for compressed files

### DIFF
--- a/lib/handle.c
+++ b/lib/handle.c
@@ -29,7 +29,28 @@
 
 const char libtar_version[] = PACKAGE_VERSION;
 
-static tartype_t default_type = { open, close, read, write };
+static intptr_t tar_openfunc(const char *pathname, int flags, int mode)
+{
+	return (intptr_t)open(pathname, flags, mode);
+}
+
+static int tar_closefunc(intptr_t fd)
+{
+	return close((int)fd);
+}
+
+static ssize_t tar_readfunc(intptr_t fd, void *buf, size_t count)
+{
+	return read((int)fd, buf, count);
+}
+
+static ssize_t tar_writefunc(intptr_t fd, const void *buf, size_t count)
+{
+	return write((int)fd, buf, count);
+}
+
+static tartype_t default_type = { tar_openfunc, tar_closefunc,
+				  tar_readfunc, tar_writefunc };
 
 
 static int
@@ -105,7 +126,7 @@ tar_fdopen(TAR **t, int fd, const char *pathname, tartype_t *type,
 }
 
 
-int
+intptr_t
 tar_fd(TAR *t)
 {
 	return t->fd;

--- a/lib/libtar.h
+++ b/lib/libtar.h
@@ -13,6 +13,7 @@
 #ifndef LIBTAR_H
 #define LIBTAR_H
 
+#include <stdint.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <linux/capability.h>
@@ -81,10 +82,10 @@ struct tar_header
 
 /***** handle.c ************************************************************/
 
-typedef int (*openfunc_t)(const char *, int, ...);
-typedef int (*closefunc_t)(int);
-typedef ssize_t (*readfunc_t)(int, void *, size_t);
-typedef ssize_t (*writefunc_t)(int, const void *, size_t);
+typedef intptr_t (*openfunc_t)(const char *, int, ...);
+typedef int (*closefunc_t)(intptr_t);
+typedef ssize_t (*readfunc_t)(intptr_t, void *, size_t);
+typedef ssize_t (*writefunc_t)(intptr_t, const void *, size_t);
 
 typedef struct
 {
@@ -99,7 +100,7 @@ typedef struct
 {
 	tartype_t *type;
 	const char *pathname;
-	long fd;
+	intptr_t fd;
 	int oflags;
 	int options;
 	struct tar_header th_buf;
@@ -139,7 +140,7 @@ int tar_fdopen(TAR **t, int fd, const char *pathname, tartype_t *type,
 	       int oflags, int mode, int options);
 
 /* returns the descriptor associated with t */
-int tar_fd(TAR *t);
+intptr_t tar_fd(TAR *t);
 
 /* close tarfile handle */
 int tar_close(TAR *t);

--- a/lib/libtar.h
+++ b/lib/libtar.h
@@ -82,7 +82,7 @@ struct tar_header
 
 /***** handle.c ************************************************************/
 
-typedef intptr_t (*openfunc_t)(const char *, int, ...);
+typedef intptr_t (*openfunc_t)(const char *, int, int);
 typedef int (*closefunc_t)(intptr_t);
 typedef ssize_t (*readfunc_t)(intptr_t, void *, size_t);
 typedef ssize_t (*writefunc_t)(intptr_t, const void *, size_t);

--- a/libtar/libtar.c
+++ b/libtar/libtar.c
@@ -57,7 +57,7 @@ segv_handler(int sig)
 
 int use_zlib = 0;
 
-int
+intptr_t
 gzopen_frontend(char *pathname, int oflags, int mode)
 {
 	char *gzoflags;
@@ -99,7 +99,7 @@ gzopen_frontend(char *pathname, int oflags, int mode)
 	   size and placement of integers is different than pointers.
 	   However, to fix the problem 4 wrapper functions would be needed and
 	   an extra bit of data associating GZF with the wrapper functions.  */
-	return (int)gzf;
+	return (intptr_t)gzf;
 }
 
 tartype_t gztype = { (openfunc_t) gzopen_frontend, (closefunc_t) gzclose,


### PR DESCRIPTION
The program should now handle compressed TWRP backups correctly.
The patch is taken from here: https://github.com/Parrot-Developers/libtar
